### PR TITLE
feat: add icon and default hotkey

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,14 @@ export function createCommands(): Command[] {
     {
       id: "cycle-task-status",
       name: "Cycle task status",
+      hotkeys: [
+        // cmd + shift + l
+        {
+          modifiers: ["Mod", "Shift"],
+          key: "L",
+        },
+      ],
+      icon: "circle-check-big",
       editorCallback: (editor: Editor) => {
         const { line, ch } = editor.getCursor();
 


### PR DESCRIPTION
# Overview

- set hotkey(cmd+shift+l) to cycle-task-status command
- set icon([circle-check-big](https://lucide.dev/icons/circle-check-big)) to cylec-task-status command