### PR TITLE
"Implement autoIncrementOnSameTime toggle and SettingTab"

### DIFF
--- a/src/LivePreview.ts
+++ b/src/LivePreview.ts
@@ -1,16 +1,17 @@
 // ref. https://github.com/sytone/obsidian-tasks/blob/main/src/LivePreviewExtension.ts
-import { EditorView, PluginValue, ViewPlugin } from "@codemirror/view";
+import { EditorView, PluginValue } from "@codemirror/view";
+
 import { Task } from "./Task";
+import { Settings } from "./settings";
+import { taskOperations } from "./operations";
 
-export const newLivePreviewExtension = () => {
-  return ViewPlugin.fromClass(LivePreviewExtension);
-};
-
-class LivePreviewExtension implements PluginValue {
+export class LivePreviewExtension implements PluginValue {
   private readonly view: EditorView;
+  private readonly settings: Settings;
 
-  constructor(view: EditorView) {
+  constructor(view: EditorView, settings: Settings) {
     this.view = view;
+    this.settings = settings;
 
     this.handleClickEvent = this.handleClickEvent.bind(this);
     this.view.dom.addEventListener("click", this.handleClickEvent);
@@ -45,9 +46,11 @@ class LivePreviewExtension implements PluginValue {
     // We need to prevent default so that the checkbox is only handled by us and not obsidian.
     event.preventDefault();
 
+    const taskOp = new taskOperations(this.settings);
+
     // Clicked on a task's checkbox. Toggle the task and set it.
     // Shift-click to cancel a task.
-    const toggled = task.toggle();
+    const toggled = taskOp.toggleTask(task);
 
     // Creates a CodeMirror transaction in order to update the document.
     const transaction = state.update({

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,9 @@
 import { Command, Editor, Notice } from "obsidian";
 import { Task } from "./Task";
+import { taskOperations } from "./operations";
+import { Settings } from "./settings";
 
-export function createCommands(): Command[] {
+export function createCommands(settings: Settings): Command[] {
   return [
     {
       id: "cycle-task-status",
@@ -11,7 +13,7 @@ export function createCommands(): Command[] {
         // cmd + shift + l
         {
           modifiers: ["Mod", "Shift"],
-          key: "L",
+          key: "l",
         },
       ],
       editorCallback: (editor: Editor) => {
@@ -26,7 +28,9 @@ export function createCommands(): Command[] {
           return;
         }
 
-        const toggled = task.toggle();
+        const taskOp = new taskOperations(settings);
+
+        const toggled = taskOp.toggleTask(task);
 
         editor.setLine(line, toggled.toString());
         editor.setCursor(line, ch);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,20 +2,16 @@ import { Plugin } from "obsidian";
 
 import { newLivePreviewExtension } from "./LivePreview";
 import { createCommands } from "./commands";
-
-interface Settings {
-  mySetting: string;
-}
-
-const DEFAULT_SETTINGS: Settings = {
-  mySetting: "default",
-};
+import { DEFAULT_SETTINGS, SettingTab, Settings } from "./settings";
 
 export default class Main extends Plugin {
   settings: Settings;
 
   async onload() {
     await this.loadSettings();
+
+    this.addSettingTab(new SettingTab(this.app, this));
+
     this.registerEditorExtension(newLivePreviewExtension());
 
     createCommands().forEach((command) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { Plugin } from "obsidian";
+import { ViewPlugin } from "@codemirror/view";
 
-import { newLivePreviewExtension } from "./LivePreview";
 import { createCommands } from "./commands";
 import { DEFAULT_SETTINGS, SettingTab, Settings } from "./settings";
+import { LivePreviewExtension } from "./LivePreview";
 
 export default class Main extends Plugin {
   settings: Settings;
@@ -12,9 +13,11 @@ export default class Main extends Plugin {
 
     this.addSettingTab(new SettingTab(this.app, this));
 
-    this.registerEditorExtension(newLivePreviewExtension());
+    this.registerEditorExtension(
+      ViewPlugin.define((view) => new LivePreviewExtension(view, this.settings))
+    );
 
-    createCommands().forEach((command) => {
+    createCommands(this.settings).forEach((command) => {
       this.addCommand(command);
     });
   }

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,0 +1,18 @@
+import { Task } from "./Task";
+import { Settings } from "./settings";
+
+export class taskOperations {
+  private readonly settings: Settings;
+
+  constructor(settings: Settings) {
+    this.settings = settings;
+  }
+
+  public toggleTask(task: Task): Task {
+    return task.toggle({
+      end_time: this.settings.autoIncrementOnSameTime
+        ? task.start?.clone().add(1, "minutes")
+        : undefined,
+    });
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab } from "obsidian";
+import { App, PluginSettingTab, Setting } from "obsidian";
 import Main from "./main";
 
 export interface Settings {
@@ -21,5 +21,19 @@ export class SettingTab extends PluginSettingTab {
     const { containerEl } = this;
 
     containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("開始時刻と終了時刻が同じ場合に終了時刻をインクリメントする")
+      .setDesc(
+        "Day Planerで、開始時刻と終了時刻が同じ場合、durationがデフォルトのものになってしまうことを避けるために使う"
+      )
+      .addToggle((tc) => {
+        tc.setValue(this.plugin.settings.autoIncrementOnSameTime).onChange(
+          async (value) => {
+            this.plugin.settings.autoIncrementOnSameTime = value;
+            await this.plugin.saveSettings();
+          }
+        );
+      });
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,25 @@
+import { App, PluginSettingTab } from "obsidian";
+import Main from "./main";
+
+export interface Settings {
+  autoIncrementOnSameTime: boolean;
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  autoIncrementOnSameTime: false,
+};
+
+export class SettingTab extends PluginSettingTab {
+  plugin: Main;
+
+  constructor(app: App, plugin: Main) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+
+    containerEl.empty();
+  }
+}


### PR DESCRIPTION
This pull request adds the `autoIncrementOnSameTime` toggle functionality and the `SettingTab` class. The `autoIncrementOnSameTime` toggle allows users to increment the end time of a task by 1 minute if the start and end times are the same. The `SettingTab` class provides a settings tab in the plugin settings where users can enable or disable the `autoIncrementOnSameTime` feature.