### PR TITLE
Change time and body separator from commna(,) to space( )

### DIFF
--- a/src/Task.test.ts
+++ b/src/Task.test.ts
@@ -209,7 +209,7 @@ describe("toString", () => {
 
     const result = task.toString();
 
-    expect(result).toBe("  - [x] 10:00-12:00,Task content");
+    expect(result).toBe("  - [x] 10:00-12:00 Task content");
   });
 
   it("should return the string representation of the task with only start time", () => {
@@ -226,7 +226,7 @@ describe("toString", () => {
 
     const result = task.toString();
 
-    expect(result).toBe("  - [x] 10:00,Task content");
+    expect(result).toBe("  - [x] 10:00 Task content");
   });
 
   it("should return the string representation of the task without start and end times", () => {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -210,7 +210,7 @@ export class Task {
     const start = this.start?.format("HH:mm") ?? "";
     const startEndSeparator = this.start && this.end ? "-" : "";
     const end = this.end?.format("HH:mm") ?? "";
-    const bodySeparator = this.start || this.end ? "," : "";
+    const bodySeparator = this.start || this.end ? " " : "";
     return (
       `${this.indentation}${this.listMarker} [${this.status.symbol}] ` +
       `${start}${startEndSeparator}${end}` +


### PR DESCRIPTION
# Why?

Initially, I was thinking of putting the task contents in CSV format to make them easier to process by machine, but I gave up on that idea.

I decided to change it because spaces are easier to input and read than commas.