### PR TITLE
Remove default hotkey

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,13 +9,6 @@ export function createCommands(settings: Settings): Command[] {
       id: "cycle-task-status",
       name: "Cycle task status",
       icon: "check-in-circle",
-      hotkeys: [
-        // cmd + shift + l
-        {
-          modifiers: ["Mod", "Shift"],
-          key: "l",
-        },
-      ],
       editorCallback: (editor: Editor) => {
         const { line, ch } = editor.getCursor();
 


### PR DESCRIPTION
Remove the default hotkeys to follow the instructions: https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid%20setting%20a%20default%20hotkey%20for%20commands