### PR TITLE
fix: Regex doesn't match when status is Doing and there is no taskBody #53 and When the status is Doing Status and the task body is empty, clicking the checkbox will change the status back to Todo #54

### DIFF
--- a/src/Task.test.ts
+++ b/src/Task.test.ts
@@ -66,6 +66,15 @@ describe("fromLine", () => {
     expect(result?.taskBody).toBe("task content");
   });
 
+  it("- [/] 10:00 ", () => {
+    const body = "- [/] 10:00 ";
+    const result = Task.fromLine(body);
+
+    expect(result?.start?.format("HH:mm")).toBe("10:00");
+    expect(result?.end).toBeUndefined();
+    expect(result?.taskBody).toBe("");
+  });
+
   it("- [x] 10:00-12:00 task content", () => {
     const body = "- [x] 10:00-12:00 task content";
     const result = Task.fromLine(body);

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -122,7 +122,7 @@ export class Task {
   }
 
   static parseDoing(line: string): Task {
-    const DOING_BODY_REGEX = /^(?<start>\d{1,2}:\d{1,2})\s+(?<taskBody>.*)/;
+    const DOING_BODY_REGEX = /^\s*(?<start>\d{1,2}:\d{1,2})\s+(?<taskBody>.*)/;
 
     const {
       indentation,
@@ -132,7 +132,7 @@ export class Task {
     } = Task.splitCheckbox(line);
     const status = Status.fromSymbol(statusSymbol);
 
-    const matchingTimes = checkboxBody.trim().match(DOING_BODY_REGEX);
+    const matchingTimes = checkboxBody.match(DOING_BODY_REGEX);
 
     if (matchingTimes === null) {
       throw new Error("Line does not match Doing regex");


### PR DESCRIPTION
# Overview

- fix regex and do not trim body before match
- add test case to prevent recurrence