### PR TITLE
update minifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "checkbox-time-tracker",
   "name": "Checkbox Time Tracker",
   "version": "0.7.7",
-  "minAppVersion": "0.15.0",
+  "minAppVersion": "1.5.12",
   "description": "Obsidian plugin for convenient time tracking using checkbox",
   "author": "UD",
   "authorUrl": "https://notes.udus.dev",

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
   "description": "Insert timestamp when you check off the checkbox",
   "author": "UD",
   "authorUrl": "https://notes.udus.dev",
-  "fundingUrl": "",
+  "fundingUrl": "https://www.buymeacoffee.com/udus",
   "isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Checkbox Time Tracker",
   "version": "0.7.7",
   "minAppVersion": "1.5.12",
-  "description": "Obsidian plugin for convenient time tracking using checkbox",
+  "description": "Insert timestamp when you check off the checkbox",
   "author": "UD",
   "authorUrl": "https://notes.udus.dev",
   "fundingUrl": "",


### PR DESCRIPTION
> "minAppVersion": "0.15.0",
> You are using newer API's, set this to the latest public build number.

[38994fa](https://github.com/udus122/checkbox-time-tracker/pull/59/commits/38994faec52c793cdbdba05312a7c93e33ea12e5)

> "description": "Obsidian plugin for convenient time tracking using checkbox",
> Avoid including sentences like "This is a plugin for Obsidian that does ..." in your description, it should be self-evident that this is a plugin for Obsidian.
> We have published a guide for plugin descriptions to follow here: docs.obsidian.md/Plugins/Releasing/Submission+requirements+for+plugins#Keep+plugin+descriptions+short+and+simple.

[a806ffb](https://github.com/udus122/checkbox-time-tracker/pull/59/commits/a806ffbdc301fd9bfea44ece0e89723b4fe128ea)

> "fundingUrl": "",
> This is meant for links to services like Buy me a coffee, GitHub sponsors and so on, if you don't have such a link remove this line.

[7a96c5a](https://github.com/udus122/checkbox-time-tracker/pull/59/commits/7a96c5a766875ff6a8ca589a7781d051be661692)

https://github.com/obsidianmd/obsidian-releases/pull/3566#issuecomment-2137696188