### PR TITLE
Release for 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.8](https://github.com/udus122/checkbox-time-tracker/compare/0.7.7...0.7.8) - 2024-06-02
+- update minifest.json by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/59
+- Use sentence case in UI by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/58
+- chore: replace moment from moment to obsidian by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/61
+
 ## [0.7.7](https://github.com/udus122/checkbox-time-tracker/compare/0.7.6...0.7.7) - 2024-05-30
 - fix: Regex doesn't match when status is Doing and there is no taskBody #53 and When the status is Doing Status and the task body is empty, clicking the checkbox will change the status back to Todo #54 by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/55
 - feat: notice caught error by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/57

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "checkbox-time-tracker",
   "name": "Checkbox Time Tracker",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "minAppVersion": "1.5.12",
   "description": "Insert timestamp when you check off the checkbox",
   "author": "UD",


### PR DESCRIPTION
This pull request is for the next release as 0.7.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.7.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.7.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update minifest.json by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/59
* Use sentence case in UI by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/58
* chore: replace moment from moment to obsidian by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/61


**Full Changelog**: https://github.com/udus122/checkbox-time-tracker/compare/0.7.7...0.7.8