### PR TITLE
Release for 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.8.1](https://github.com/udus122/checkbox-time-tracker/compare/0.8.0...0.8.1) - 2024-06-15
+- update packages by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/67
+
 ## [0.8.0](https://github.com/udus122/checkbox-time-tracker/compare/0.7.8...0.8.0) - 2024-06-15
 - Introduce the date display by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/64
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "checkbox-time-tracker",
   "name": "Checkbox Time Tracker",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "minAppVersion": "1.5.12",
   "description": "Insert timestamp when you check off the checkbox",
   "author": "UD",


### PR DESCRIPTION
This pull request is for the next release as 0.8.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.8.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.8.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update packages by @udus122 in https://github.com/udus122/checkbox-time-tracker/pull/67


**Full Changelog**: https://github.com/udus122/checkbox-time-tracker/compare/0.8.0...0.8.1